### PR TITLE
Remove an extra List.rev

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -62,6 +62,11 @@ module Drum = struct
       failwith "numero invalide"
 end
 
+let print_sequence s =
+  List.iter (fun (t, elt) ->
+    Printf.printf "%d:  %d\n" t (List.length elt);
+  ) s;
+  flush_all ()
 module Sequence = struct 
 
   type evenement = 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -151,7 +151,7 @@ module Sequence = struct
         aux r1 l2 ((t1, e1)::c)
       | [], [] -> c 
       in
-      List.rev (aux l1 l2 [])
+      aux l1 l2 []
     let fusion instructions =
       let rec aux l resultat =
         match l with


### PR DESCRIPTION
This PR introduces a fix.
`merge_assoc` does not need to reverse the list, because it happens that the star aligns later and everything is in the right order.

This is not best practices, but this is only a training. :-)

Also I added a debugging function.